### PR TITLE
Adding group member

### DIFF
--- a/dojo/group/views.py
+++ b/dojo/group/views.py
@@ -25,6 +25,8 @@ from dojo.group.queries import get_authorized_groups, get_product_groups_for_gro
 from dojo.authorization.authorization_decorators import user_is_configuration_authorized
 from dojo.authorization.authorization import user_has_configuration_permission, user_has_permission_or_403
 from dojo.group.utils import get_auth_group_name
+from dojo.authorization.roles_permissions import Permissions
+from dojo.models import Role
 
 logger = logging.getLogger(__name__)
 
@@ -324,6 +326,14 @@ class AddGroup(View):
                 global_role = context["global_role_form"].save(commit=False)
                 global_role.group = group
                 global_role.save()
+                # Add current user to the new group
+                group_member = Dojo_Group_Member()
+                group_member.group = group
+                group_member.user = request.user
+                role_name="Owner"
+                group_member.role = Role.objects.get(name=role_name)
+                group_member.role.id = 4
+                group_member.save()
                 messages.add_message(
                     request,
                     messages.SUCCESS,

--- a/dojo/group/views.py
+++ b/dojo/group/views.py
@@ -25,7 +25,6 @@ from dojo.group.queries import get_authorized_groups, get_product_groups_for_gro
 from dojo.authorization.authorization_decorators import user_is_configuration_authorized
 from dojo.authorization.authorization import user_has_configuration_permission, user_has_permission_or_403
 from dojo.group.utils import get_auth_group_name
-from dojo.authorization.roles_permissions import Permissions
 from dojo.models import Role
 
 logger = logging.getLogger(__name__)
@@ -330,8 +329,8 @@ class AddGroup(View):
                 group_member = Dojo_Group_Member()
                 group_member.group = group
                 group_member.user = request.user
-                role_name="Owner"
-                group_member.role = Role.objects.get(name=role_name)
+                role_name = "Owner"
+                group_member.role = Role.objects.get(name = role_name)
                 group_member.role.id = 4
                 group_member.save()
                 messages.add_message(


### PR DESCRIPTION

**Description**

As per DefectDojo's documentation "If users create a new Group, they will be given the Owner role of the new Group by default. https://support.defectdojo.com/en/articles/8758189-about-permissions-roles#h_cd25e87a4e" This was not reflecting in DefectDojo's code. When a user created a new group, he was not added in the group at all.

Adding logic to add the user as owner whenever he creates the group.